### PR TITLE
Trigger toggle asynchronously, with a slight delay

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,14 @@ import { TextEditorSelectionChangeKind } from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
 	if (vscode.workspace.getConfiguration("vtools").autoHideSideBar) {
-		vscode.window.onDidChangeTextEditorSelection(selection=> {
+		vscode.window.onDidChangeTextEditorSelection(selection => {
 			if (selection.kind != TextEditorSelectionChangeKind.Mouse || selection.selections.length == 0) return;
-			if (selection.selections.find(a=>a.isEmpty) == null) return;
-			//vscode.commands.executeCommand("workbench.files.action.focusFilesExplorer");
-			vscode.commands.executeCommand("workbench.extensions.action.showInstalledExtensions");
-			vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility");
+			if (selection.selections.find(a => a.isEmpty) == null) return;
+			setTimeout(function () {
+				//vscode.commands.executeCommand("workbench.files.action.focusFilesExplorer");
+				vscode.commands.executeCommand("workbench.extensions.action.showInstalledExtensions");
+				vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility");
+			}, 150);
 		});
 	}
 }


### PR DESCRIPTION
Avoids accidental text selection when buffer position changes during
mouse-click.

I often find myself accidentally selecting text when the auto-toggle kicks in because the buffer changes position while the mouse-button is still depressed.  Adding a small delay mostly solves the problem, though being able to execute the toggle on the back of mouse-up instead of the focus event would solve the problem entirely, without any delay.  Not sure if there's a sensible API hook to implement the latter, so this does the job in the mean time.