### PR TITLE
* * Added "auto-hide output" setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Extension install page: <https://marketplace.visualstudio.com/items?itemName=ven
 
 ## Features
 
-### Auto-hide side-bar
-Causes the side-bar to be hidden whenever the user clicks outside of it. (technically, when the user changes the text-editor selection)
+### Auto-hide side-bar/Output
+Causes the side-bar and/or output windows to be hidden whenever the user clicks outside of it. (technically, when the user changes the text-editor selection)
 
 ![Auto-hide side-bar](Images/Features/AutoHideSideBar.gif)
 
 ## Settings
 
 * `vtools.autoHideSideBar`: Causes the side-bar to be hidden whenever the user clicks outside of it. [boolean, default: `false`]
+* `vtools.autoHideOutput`: Causes the problems/output/debug consol/terminal window to be hidden whenever the user clicks outside of it. [boolean, default: `false`]
 * `vtools.autoHideDelay`: How long to wait (after the user clicks outside of the side-bar) before hiding the side-bar. (helps solve the unintended-selection issue -- especially when scrolled to the right) [number, default: `300`]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-vtools",
     "displayName": "VTools",
     "description": "A collection of small tools for Visual Studio Code.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "venryx",
 	"repository": "https://github.com/Venryx/vscode-vtools",
 	"icon": "Images/Icons/Logo_128.png",
@@ -30,7 +30,12 @@
 					"type": "number",
 					"default": 300,
 					"description": "How long to wait (after the user clicks outside of the side-bar) before hiding the side-bar. (helps solve the unintended-selection issue -- especially when scrolled to the right)"
-				}
+				},
+                "vtools.autoHideOutput": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Causes the problems/output/debug consol/terminal window to be hidden whenever the user clicks outside of it."
+                }
 			}
 		}
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,28 @@ export function activate(context: vscode.ExtensionContext) {
 			lastSelectionTime = thisSelectionTime;
 		});
 	}
+
+	if (vscode.workspace.getConfiguration("vtools").autoHideOutput) {
+		vscode.window.onDidChangeTextEditorSelection(selection=> {
+			// if selection was not from a click, or if there are no selections, return
+			if (selection.kind != TextEditorSelectionChangeKind.Mouse || selection.selections.length == 0) return;
+
+			// if at least one editor's selection is a single-position (ie. not a segment of text), perform the side-bar hiding
+			var singlePos = selection.selections.find(a=>a.isEmpty) != null;
+			var thisSelectionTime = Date.now();
+			if (singlePos) {
+				setTimeout(function () {
+					// if the selection changed during the delay-time, cancel the side-bar hiding
+					if (lastSelectionTime != thisSelectionTime) return;
+
+					//vscode.commands.executeCommand("workbench.files.action.focusFilesExplorer");
+					vscode.commands.executeCommand("workbench.action.terminal.focus");
+					vscode.commands.executeCommand("workbench.action.terminal.toggleTerminal");
+				}, vscode.workspace.getConfiguration("vtools").autoHideDelay);
+			}
+			lastSelectionTime = thisSelectionTime;
+		});
+	}
 }
 export function deactivate() {
 }


### PR DESCRIPTION
Similar to hiding the side-bar, some users might like having the output window auto-hide as well. 
This change adds a new setting to enable/disable automatically hiding the output window. The two settings are independent of each other.

NOTE:  In order to debug these changes, don't forget to uncomment the prepublish, compile, and postinstall scripts in package.json.