### PR TITLE
vscode 1.28 update fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-vtools",
 	"displayName": "VTools",
 	"description": "A collection of small tools for Visual Studio Code.",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"publisher": "venryx",
 	"repository": "https://github.com/Venryx/vscode-vtools",
 	"icon": "Images/Icons/Logo_128.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,8 +20,6 @@ export function activate(context: vscode.ExtensionContext) {
 					if (lastSelectionTime != thisSelectionTime) return;
 
 					if (config.autoHideSideBar) {
-						//vscode.commands.executeCommand("workbench.files.action.focusFilesExplorer");
-						//vscode.commands.executeCommand("workbench.extensions.action.showInstalledExtensions");
 						vscode.commands.executeCommand("workbench.view.search");
 						vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility");
 					}
@@ -30,7 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 					let pathIsFile = path.includes(".") || path.includes("\\") || path.includes("/");
 					if (config.autoHideBottomBar && pathIsFile) {
 						vscode.commands.executeCommand("workbench.action.terminal.focus");
- 						vscode.commands.executeCommand("workbench.action.terminal.toggleTerminal");
+						vscode.commands.executeCommand("workbench.action.togglePanel");
 					}
 				}, vscode.workspace.getConfiguration("vtools").autoHideDelay);
 			}


### PR DESCRIPTION
Correcting the terminal toggling behavior after the changes made to the workbench.action.terminal.toggleTerminal command in Visual Studio Code v1.28.